### PR TITLE
feat: nillable as optional

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,6 +79,11 @@ const argv = await yargs(hideBin(process.argv))
     default: true,
     desc: "Emit errors if any type references cannot be resolved in the WSDL schema",
   })
+  .option("nillable-as-optional", {
+    type: "boolean",
+    default: false,
+    desc: "Emit nillable elements as optional properties in types.",
+  })
   .strict()
   .help()
   .parse();
@@ -105,6 +110,7 @@ const compiled = compileCatalog(
     failOnUnresolved: argv["fail-on-unresolved"] as boolean,
     attributesKey: argv["attributes-key"] as string,
     clientName: argv["client-name"] as string | undefined,
+    nillableAsOptional: argv["nillable-as-optional"] as boolean,
   }
 );
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,8 @@ export type CompilerOptions = {
   attributesKey?: string;
   /** Override the generated client class name (from --client-name). */
   clientName?: string;
+  /** Emit nillable elements as optional properties in types. */
+  nillableAsOptional?: boolean
 };
 
 /**
@@ -42,4 +44,5 @@ export const TYPESCRIPT_WSDL_CLIENT_DEFAULT_COMPLIER_OPTIONS: CompilerOptions = 
   failOnUnresolved: false,        // CLI default
   attributesKey: "$attributes",   // CLI default
   clientName: undefined,          // no default
+  nillableAsOptional: false,      // CLI default
 };

--- a/src/emit/typesEmitter.ts
+++ b/src/emit/typesEmitter.ts
@@ -126,7 +126,7 @@ export function emitTypes(outFile: string, compiled: CompiledCatalog) {
     for (const e of elementsToEmit) {
       const isArray = e.max === "unbounded" || (e.max > 1);
       const arr = isArray ? "[]" : "";
-      const opt = (e.min ?? 0) === 0 ? "?" : "";
+      const opt = (compiled.options.nillableAsOptional && e.nillable) || (e.min ?? 0) === 0 ? "?" : "";
       const annObj = {
         // if a.name === "$value", the kind should be "scalar value"
         kind: e.name === "$value" ? "scalar value" : "element" as const,


### PR DESCRIPTION
## Summary

This PR introduces a new option to the CLI and programmatic api to always generate `nillable` elements as optional properties.

Fixes #7

This change is non-breaking as the default value for the property is false.

## Checklist

- [ ] Includes a minimal WSDL/XSD fixture or link to a gist if relevant
- [ ] Tests or a smoke step cover the change (when applicable)
- [x] Docs updated (README/CLI help) if user-facing
- [x] No breaking changes or clearly documented

## How to test

Commands and steps to validate locally:

```
npm ci
npm run build
npm run typecheck
# optional smoke
npm run smoke
```

