### PR TITLE
fix: programmatic api utils name mismatch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export async function compileWsdlToProject(
 
   // Emit artifacts
   const typesFile = path.join(input.outDir, "types.ts");
-  const metaFile = path.join(input.outDir, "meta.ts");
+  const utilsFile = path.join(input.outDir, "utils.ts");
   const catalogFile = path.join(input.outDir, "catalog.json");
   const clientFile = path.join(input.outDir, "client.ts");
 
@@ -60,7 +60,7 @@ export async function compileWsdlToProject(
   // Emit files
   emitClient(clientFile, compiled);
   emitTypes(typesFile, compiled);
-  emitUtils(metaFile, compiled);
+  emitUtils(utilsFile, compiled);
 
   if (compiled.options.catalog) {
     emitCatalog(catalogFile, compiled);


### PR DESCRIPTION
## Summary

This PR resolves an issue in the programmatic usage of this library where the `utils` file is generated as `meta`.

If you generate the wsdl client with programmatic api at the moment you end up with errors on the import of the utils from the client. It expects the file to be called `utils` but instead the generated file is `meta`.

<img width="934" height="240" alt="image" src="https://github.com/user-attachments/assets/b2031210-6498-4b0b-a57e-6cac7d646f6c" />


## Checklist

- [ ] Includes a minimal WSDL/XSD fixture or link to a gist if relevant
- [ ] Tests or a smoke step cover the change (when applicable)
- [ ] Docs updated (README/CLI help) if user-facing
- [x] No breaking changes or clearly documented

## How to test

Commands and steps to validate locally:

```
npm ci
npm run build
npm run typecheck
# optional smoke
npm run smoke
```

